### PR TITLE
🐛 string postcss plugin broken in pnpm monorepo

### DIFF
--- a/.changeset/orange-geese-clean.md
+++ b/.changeset/orange-geese-clean.md
@@ -1,0 +1,5 @@
+---
+"@aiou/react-template": patch
+---
+
+string postcss plugin broken in pnpm monorepo

--- a/build/webpack.prod.config.js
+++ b/build/webpack.prod.config.js
@@ -61,7 +61,7 @@ const prod = {
       new CssMinimizerPlugin({
         minimizerOptions: {
           preset: [
-            'advanced',
+            require.resolve('cssnano-preset-advanced'),
             {
               autoprefixer: false,
             },

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,23 +1,23 @@
 module.exports = {
   plugins: [
     [
-      'postcss-preset-env',
+      require('postcss-preset-env'),
       {
         autoprefixer: {
           browserslits: ['> 1%'],
         },
       },
     ],
-    'rucksack-css',
-    'postcss-import',
-    'postcss-url',
+    require('rucksack-css'),
+    require('postcss-import'),
+    require('postcss-url'),
     [
-      'cssnano',
+      require.resolve('cssnano'),
       {
-        preset: 'advanced',
+        preset: require.resolve('cssnano-preset-advanced'),
         autoprefixer: false,
       },
     ],
-    'tailwindcss',
+    require('tailwindcss'),
   ],
 }

--- a/src/typings/component.d.ts
+++ b/src/typings/component.d.ts
@@ -1,6 +1,0 @@
-export type Props<T> =
-  | (JSX.IntrinsicAttributes &
-      React.PropsWithoutRef<T> &
-      // tslint:disable-next-line
-      React.RefAttributes<React.Component<T, any, any>>)
-  | (JSX.IntrinsicAttributes & React.PropsWithRef<React.PropsWithChildren<T>>)


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

**What kind of change does this PR introduce?** (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe:

**Does this PR introduce a breaking change?** (check one)

- [ ] Yes
- [x] No

use require to load postcss plugins, make sure load successful in monorepo
